### PR TITLE
Remove AddCanonicalTag middleware from HTTP kernel and comment out re…

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -15,7 +15,7 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
-        \App\Http\Middleware\AddCanonicalTag::class,
+        // \App\Http\Middleware\AddCanonicalTag::class,
         \App\Http\Middleware\TrustProxies::class,
         \Illuminate\Http\Middleware\HandleCors::class,
         \App\Http\Middleware\PreventRequestsDuringMaintenance::class,

--- a/resources/views/admin/layouts/partials/header.blade.php
+++ b/resources/views/admin/layouts/partials/header.blade.php
@@ -19,9 +19,9 @@
     <!-- ===============================================-->
     <meta name="csrf-token" content="{{ csrf_token() }}">
                                                                             <!-- Canonical URL için bölüm -->
-                                                                            @if(isset($canonicalUrl))
+                                                                            {{-- @if(isset($canonicalUrl))
                                                                                 <link rel="canonical" href="{{ $canonicalUrl }}" />
-                                                                            @endif
+                                                                            @endif --}}
     <link rel="apple-touch-icon" sizes="180x180"
         href="{{ URL::to('/') }}/favicon.png">
     <link rel="icon" type="image/png" sizes="32x32"

--- a/resources/views/client/layouts/partials/header.blade.php
+++ b/resources/views/client/layouts/partials/header.blade.php
@@ -24,9 +24,9 @@
 
     <!-- FAVICON -->
                                                                                 <!-- Canonical URL için bölüm -->
-                                                                                @if(isset($canonicalUrl))
+                                                                                {{-- @if(isset($canonicalUrl))
                                                                                         <link rel="canonical" href="{{ $canonicalUrl }}" />
-                                                                                @endif
+                                                                                @endif --}}
     <link rel="shortcut icon" type="image/x-icon" href="{{ URL::to('/') }}/favicon.png">
     <link rel="stylesheet" href="{{ URL::to('/') }}/css/jquery-ui.css">
     <!-- GOOGLE FONTS -->

--- a/resources/views/institutional/layouts/partials/header.blade.php
+++ b/resources/views/institutional/layouts/partials/header.blade.php
@@ -19,9 +19,9 @@
     <!-- ===============================================-->
     <meta name="csrf-token" content="{{ csrf_token() }}">
                                                                                 <!-- Canonical URL için bölüm -->
-                                                                                @if(isset($canonicalUrl))
+                                                                                {{-- @if(isset($canonicalUrl))
                                                                                      <link rel="canonical" href="canonical-url" />
-                                                                                @endif
+                                                                                @endif --}}
     <link rel="apple-touch-icon" sizes="180x180"
         href="{{ URL::to('/') }}/favicon.png">
     <link rel="icon" type="image/png" sizes="32x32"


### PR DESCRIPTION
…lated Blade code

The `AddCanonicalTag` middleware has been removed from the list of middleware in the HTTP kernel. The related Blade code for adding a