### PR TITLE
Fixed spacing and formatting in meta description tags

### DIFF
--- a/app/Http/Controllers/Api/Client/HousingController.php
+++ b/app/Http/Controllers/Api/Client/HousingController.php
@@ -56,7 +56,7 @@ class HousingController extends Controller {
         $pageInfo = [
             'meta_title' => $housing->title,
             'meta_keywords' => 'Emlak Sepette,İkinci el konut,konut',
-            'meta_description' => 'Emlak Kulüpte' . $housing->title . 'ile hayallerinizdeki konutu bulabilirsiniz. Geniş seçenekler, uygun fiyatlar ve 
+            'meta_description' => 'Emlak Kulüpte ' . $housing->title . ' ile hayallerinizdeki konutu bulabilirsiniz. Geniş seçenekler, uygun fiyatlar ve 
                 konforlu yaşam standartları sizi bekliyor. Her bütçeye uygun ev seçenekleriyle kaliteli bir yaşam sizleri bekliyor!',
             'meta_author' => 'Emlak Sepette',
         ];

--- a/app/Http/Controllers/Client/HousingController.php
+++ b/app/Http/Controllers/Client/HousingController.php
@@ -144,7 +144,7 @@ class HousingController extends Controller {
             $pageInfo = [
                 'meta_title' => $housing->title,
                 'meta_keywords' => 'Emlak Sepette,İkinci el konut,konut',
-                'meta_description' => 'Emlak Kulüpte' . $housing->title . 'ile hayallerinizdeki konutu bulabilirsiniz. Geniş seçenekler, uygun fiyatlar ve konforlu yaşam sizi bekliyor!
+                'meta_description' => 'Emlak Kulüpte ' . $housing->title . ' ile hayallerinizdeki konutu bulabilirsiniz. Geniş seçenekler, uygun fiyatlar ve konforlu yaşam sizi bekliyor!
                     Şimdi alım yapın.Geleceğe yatırım yapın.',
                 'meta_author' => 'Emlak Sepette',
             ];

--- a/app/Http/Controllers/Client/InstitutionalController.php
+++ b/app/Http/Controllers/Client/InstitutionalController.php
@@ -165,7 +165,7 @@ class InstitutionalController extends Controller
         $pageInfo = [
             "meta_title" => $institutional->name,
             "meta_keywords" => "Emlak Sepette," . $institutional->name,
-            "meta_description" => "Emlak Kulüp " . $institutional->name.'uzman ekibimizle en iyi gayrimenkul çözümlerini keşfedin. Güvenilir hizmet ve geniş seçeneklerle hayallerinizi gerçekleştirin!',
+            "meta_description" => "Emlak Kulüp " . $institutional->name.' uzman ekibimizle en iyi gayrimenkul çözümlerini keşfedin. Güvenilir hizmet ve geniş seçeneklerle hayallerinizi gerçekleştirin!',
             "meta_author" => "Emlak Sepette",
         ];
 
@@ -202,7 +202,7 @@ class InstitutionalController extends Controller
         $pageInfo = [
             "meta_title" => $institutional->name,
             "meta_keywords" => "Emlak Sepette," . $institutional->name,
-            "meta_description" => "Emlak Kulüp " . $institutional->name .'uzman ekibimizle en iyi gayrimenkul çözümlerini keşfedin. Güvenilir hizmet, geniş seçenekler ve uygun fiyatlarla hayallerinizi gerçekleştirin!',
+            "meta_description" => "Emlak Kulüp " . $institutional->name .' uzman ekibimizle en iyi gayrimenkul çözümlerini keşfedin. Güvenilir hizmet, geniş seçenekler ve uygun fiyatlarla hayallerinizi gerçekleştirin!',
             "meta_author" => "Emlak Sepette",
         ];
 

--- a/app/Http/Controllers/Client/ProjectController.php
+++ b/app/Http/Controllers/Client/ProjectController.php
@@ -1156,7 +1156,7 @@ class ProjectController extends Controller
                         : "Emlak Sepette"),
                 "meta_keywords" => $project->project_title . "Proje,Proje Detay," . $project->city->title,
                 "meta_description" => isset($projectHousingsList[$housingOrder]['advertise_title[]'])
-                    ? $projectHousingsList[$housingOrder]['advertise_title[]'.'Emlak Sepette projeleri sizler için muhteşem, benzersiz mimari tasarımı ve modern yaşam konseptiyle dikkat çekiyor. Doğa ile iç içe, lüks ve konfor dolu bir yaşamın kapılarını aralayın.Tasarımlarımıza göz gezdirin ve alışverişe başlayın!']
+                    ? $projectHousingsList[$housingOrder]['advertise_title[]'.' Emlak Sepette projeleri sizler için muhteşem, benzersiz mimari tasarımı ve modern yaşam konseptiyle dikkat çekiyor. Doğa ile iç içe, lüks ve konfor dolu bir yaşamın kapılarını aralayın.Tasarımlarımıza göz gezdirin ve alışverişe başlayın!']
                     : (isset($projectHousingsList[$housingOrder]['advertise-title[]'])
                         ? $projectHousingsList[$housingOrder]['advertise-title[]'.'Emlak Sepette projeleri sizler için muhteşem, benzersiz mimari tasarımı ve modern yaşam konseptiyle dikkat çekiyor. Doğa ile iç içe, lüks ve konfor dolu bir yaşamın kapılarını aralayın.Tasarımlarımıza göz gezdirin ve alışverişe başlayın!']
                         : "Emlak Sepette projeleri sizler için muhteşem, benzersiz mimari tasarımı ve modern yaşam konseptiyle dikkat çekiyor. Doğa ile iç içe, lüks ve konfor dolu bir yaşamın kapılarını aralayın.Tasarımlarımıza göz gezdirin ve alışverişe başlayın!"),


### PR DESCRIPTION
This commit fixes some spacing and formatting issues in the meta description tags in several files. Specifically, it adds a space after the colon in the meta_description property in