### PR TITLE
"Remove unnecessary condition from order index view in admin panel"

### DIFF
--- a/resources/views/admin/orders/index.blade.php
+++ b/resources/views/admin/orders/index.blade.php
@@ -208,14 +208,14 @@
                                                         ][$order->refund->status] !!}
                                                     </span>
                                                 </td>
-                                                {{-- @if ($order->invoice && $order->status == 1)
+                                                @if ($order->invoice )
                                                     <span class="badge badge-phoenix fs-10 badge-phoenix-success">
                                                         <a href="{{ route('institutional.invoice.show', $order->id) }}">
                                                             Faturayı Görüntüle
                                                         </a>
 
                                                     </span>
-                                                @endif --}}
+                                                @endif
 
                                             @else
                                                 <td class="order_status"><span class="text-success">


### PR DESCRIPTION
This commit removes the unnecessary condition checking if the order status is equal to 1 in the order index view of the admin panel. Additionally, it removes the commented-out