### PR TITLE
"Updated Swal.fire() method in footer.blade.php to use 'text' instead…

### DIFF
--- a/resources/views/client/layouts/partials/footer.blade.php
+++ b/resources/views/client/layouts/partials/footer.blade.php
@@ -329,7 +329,7 @@
         Swal.fire({
             position: "center",
             icon: "warning",
-            title: errorMessage,
+            text: errorMessage,
             showClass: {
                 popup: `
       animate__animated
@@ -356,7 +356,7 @@
         Swal.fire({
             position: "center",
             icon: "success",
-            title: successMessage,
+            text: successMessage,
             showClass: {
                 popup: `
       animate__animated


### PR DESCRIPTION
… of 'title' for error and success messages."